### PR TITLE
fix: add additional instructions in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ This script can be installed with git:
 		
 	git clone https://github.com/myDevicesIoT/iotinabox-python-example-app.git
 
+Install the python requests library by opening up a terminal and typing:
+
+        pip install requests
 
 Setup:
 -------------

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Install the python requests library by opening up a terminal and typing:
 
 Setup:
 -------------
-Obtain your IoTInABox credentials (ClientID and Client Secret) from your account. Input these into the indicated spots in the server.py program, which you can edit with any text editor.
+Obtain your IoTInABox credentials (ClientID and Client Secret) from your account. Input your client ID in the login.html file where indicated, and enter the client ID and client secret in the server.py file. Both files can be opened by text editors.
 
 To run the script, simply open up a terminal and type:
 

--- a/server.py
+++ b/server.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, url_for, request, redirect, jsonify, send_from_directory
+from flask import Flask, request, redirect, jsonify, send_from_directory
 import requests
 import json
 app = Flask(__name__, static_url_path='/static')

--- a/static/login.html
+++ b/static/login.html
@@ -19,7 +19,8 @@
             <div class="container-fluid" >
                 <h1 class="header text-center text-success">Login With Iot In A Box</h1>
                 <form role="form">
-                    <a class="btn btn-primary" href = 'https://va-staging-keycloak.mydevices.com/auth/realms/iotinabox/protocol/openid-connect/auth?client_id=python-example-app&redirect_uri=http://localhost:5000/auth/cb&state=1232&response_type=code'>Login</a>
+                    <!--enter your client ID in the link below-->
+                    <a class="btn btn-primary" href = 'https://va-staging-keycloak.mydevices.com/auth/realms/iotinabox/protocol/openid-connect/auth?client_id=[YOUR CLIENT ID]&redirect_uri=http://localhost:5000/auth/cb&state=1232&response_type=code'>Login</a>
                 </form> <br>
             </div>
             


### PR DESCRIPTION
A missing instruction led to an error concerning the login.html file where the auth url generated a code for the wrong client.